### PR TITLE
fileMappings keys should be urlDecoded

### DIFF
--- a/src/GToolkit4LSP/GtLSPDirectoryModel.class.st
+++ b/src/GToolkit4LSP/GtLSPDirectoryModel.class.st
@@ -220,7 +220,7 @@ GtLSPDirectoryModel >> fileMappings [
 					ifFalse: [ [ :each | each asLowercase ] ].
 			fileMappings := Dictionary new.
 			self files
-				do: [ :each | fileMappings at: (uriBlock value: each filename uri printString) put: each ].
+				do: [ :each | fileMappings at: (uriBlock value: each filename uri printString urlDecoded) put: each ].
 			fileMappings ]
 ]
 


### PR DESCRIPTION
### Issue
When using `GtLSPDirectoryModel` with diagnostics the `fileForUri` is trying to access a key (fileName) from `fileMappings`. The issue arises when opening a file within a folder that contains spaces. Essentially comparing a decoded file uri to an encoded file uri.

Before Change:
<img width="255" height="138" alt="before" src="https://github.com/user-attachments/assets/c870d987-08c5-4104-bff4-4787b2106eac" />

After Change:
<img width="255" height="138" alt="after" src="https://github.com/user-attachments/assets/5908be0f-94ac-4fcc-94a5-0fe0c5992be3" />

#### Reproduction Case
Just make a copy of `gtoolkit-boxer` (e.g. `gtoolkit-boxer - Copy`) and open on the Copy directory. Diagnostics will not work.
```smalltalk
GtLSPRustModel
	onDirectory: (GtResourcesUtility default resourceAtPath: Path * 'feenkcom' / 'gtoolkit-boxer - Copy')
```
